### PR TITLE
DAG-1708: log full request for /bfgs in starlette middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.5.0 - 2022-04-28
+- Add ability to log out the request on a failed api call.
+
 ## 0.4.7 - 2021-08-16
 - Enabling configuring multiple logs with json format.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'python-service-tools'
-version = '0.4.7'
+version = '0.5.0'
 description = "Utilities for working with python services."
 authors = [
     "Alexander Costas <alexander.costas@mongodb.com>",

--- a/tests/servicetools/test_middleware.py
+++ b/tests/servicetools/test_middleware.py
@@ -6,27 +6,42 @@ import pytest
 import servicetools.middleware as under_test
 
 
+def create_mock_request() -> MagicMock:
+    url = MagicMock(path="fake-path")
+    request = MagicMock(method="POST", url=url)
+    request_wrapper = Future()
+    request_body = "fake-body"
+    request_wrapper.set_result(request_body)
+    request.json.return_value = request_wrapper
+    request._receive.return_value = request_wrapper
+    return request
+
+
+def create_mock_response_wrapper(status_code: int) -> MagicMock:
+    response = MagicMock(status_code=status_code)
+    response_wrapper = Future()
+    response_wrapper.set_result(response)
+    return response_wrapper
+
+
 class TestStructlogRequestMiddleWare:
     @pytest.mark.asyncio
     async def test_start_and_end_requests_logged(self):
-        request = MagicMock()
-        response = MagicMock(status_code=200)
-        response_wrapper = Future()
-        response_wrapper.set_result(response)
+        request = create_mock_request()
+
+        response_wrapper = create_mock_response_wrapper(200)
         logger = MagicMock()
 
         middleware = under_test.StructlogRequestMiddleware(MagicMock(), logger=logger)
 
-        response = await middleware.dispatch(request, lambda _: response_wrapper)
+        await middleware.dispatch(request, lambda _: response_wrapper)
 
         assert logger.log.call_count == 2
 
     @pytest.mark.asyncio
     async def test_exception_logging(self):
-        request = MagicMock()
-        response = MagicMock(status_code=200)
-        response_wrapper = Future()
-        response_wrapper.set_result(response)
+        request = create_mock_request()
+
         logger = MagicMock()
 
         def throw_error(_):
@@ -35,36 +50,50 @@ class TestStructlogRequestMiddleWare:
         middleware = under_test.StructlogRequestMiddleware(MagicMock(), logger=logger)
 
         with pytest.raises(ValueError):
-            response = await middleware.dispatch(request, throw_error)
+            await middleware.dispatch(request, throw_error)
 
         assert logger.log.call_count == 2
 
     @pytest.mark.asyncio
     async def test_error_logging(self):
-        request = MagicMock()
-        response = MagicMock(status_code=404)
-        response_wrapper = Future()
-        response_wrapper.set_result(response)
+        request = create_mock_request()
+
+        response_wrapper = create_mock_response_wrapper(404)
         logger = MagicMock()
 
         middleware = under_test.StructlogRequestMiddleware(MagicMock(), logger=logger)
 
-        response = await middleware.dispatch(request, lambda _: response_wrapper)
+        await middleware.dispatch(request, lambda _: response_wrapper)
 
         assert logger.log.call_count == 3
 
     @pytest.mark.asyncio
+    async def test_error_logging_include_request(self):
+        request = create_mock_request()
+
+        response_wrapper = create_mock_response_wrapper(400)
+        logger = MagicMock()
+
+        middleware = under_test.StructlogRequestMiddleware(
+            MagicMock(), logger=logger, include_request_in_failed_requests=True
+        )
+
+        await middleware.dispatch(request, lambda _: response_wrapper)
+
+        assert logger.log.call_count == 3
+        assert logger.log.mock_calls[2][2]["request"] == "fake-body"
+
+    @pytest.mark.asyncio
     async def test_ignored_error_logging(self):
-        request = MagicMock()
-        response = MagicMock(status_code=404)
-        response_wrapper = Future()
-        response_wrapper.set_result(response)
+        request = create_mock_request()
+
+        response_wrapper = create_mock_response_wrapper(404)
         logger = MagicMock()
 
         middleware = under_test.StructlogRequestMiddleware(
             MagicMock(), logger=logger, ignored_status_codes={404}
         )
 
-        response = await middleware.dispatch(request, lambda _: response_wrapper)
+        await middleware.dispatch(request, lambda _: response_wrapper)
 
         assert logger.log.call_count == 2


### PR DESCRIPTION
Sample error

```
{"message": "HTTP request error", "lineno": 57, "filename": "middleware.py", "method": "POST", "endpoint": "/api/bfgs", "status_code": 400, "request": {"task_id": "string"}, "logger": "bbserver.webapp", "level": "info"}
```